### PR TITLE
Add a fix for the supabase not auto loggin off when the wallet sessio…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,7 +75,8 @@ export default function Home() {
   const { formattedBalance: formattedSmartBalance } = useUSDCBalance(cdpAuth.smartAccountAddress);
   const { formattedBalance: formattedEoaBalance } = useUSDCBalance(cdpAuth.eoaAddress);
   
-  const isAuthenticated = walletAuth.isAuthenticated || cdpAuth.isAuthenticated;
+  // Require both authentication AND a valid wallet address
+  const isAuthenticated = (walletAuth.isAuthenticated || cdpAuth.isAuthenticated) && !!currentWalletAddress;
   const authError = walletAuth.error || cdpAuth.error;
   
   const { contacts, loadContacts } = useContacts(currentWalletAddress);

--- a/src/lib/auth/useCDPAuth.ts
+++ b/src/lib/auth/useCDPAuth.ts
@@ -94,6 +94,26 @@ export function useCDPAuth() {
     }
   }, [currentUser]);
 
+  // Auto sign out from Supabase when CDP wallet session expires
+  useEffect(() => {
+    const checkAndSignOut = async () => {
+      // If CDP is not signed in but we have a Supabase session, sign out of Supabase
+      if (isCDPSignedIn === false && session) {
+        console.log("CDP session expired, signing out of Supabase");
+        await supabase.auth.signOut();
+        clearAllCache();
+        setStatus("signed_out");
+        setSession(null);
+        setUser(null);
+        setWalletAddress(null);
+        setSmartAccountAddress(null);
+        setEoaAddress(null);
+      }
+    };
+    
+    checkAndSignOut();
+  }, [isCDPSignedIn, session]);
+
   useEffect(() => {
     const syncWithSupabase = async () => {
       if (isCDPSignedIn && currentUser) {


### PR DESCRIPTION
…n expires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now requires both a validated user session and a connected wallet address before granting access.

* **Improvements**
  * Users are automatically signed out when their wallet session expires; local cache and session state are cleared and reset to prevent stale access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->